### PR TITLE
fix: configure bring content to run at all frames

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -36,7 +36,8 @@
       "js": [
         "app/bringContent.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "action": {


### PR DESCRIPTION
This pull request makes a minor update to the Chrome extension manifest to ensure content scripts are injected into all frames, not just the main frame.

* [`public/manifest.json`](diffhunk://#diff-639916bc14c3f311c31f629a2ec116292a4b2f64d06b3607b9ddd2e495703895L39-R40): Added the `all_frames: true` property to the content script configuration to enable script injection in every frame of the page.